### PR TITLE
fix(docker): reduces image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.12 AS builder
 
 # Dependencies
 RUN apt-get update \
@@ -19,8 +19,7 @@ COPY controllers /build/controllers
 RUN go build ./main.go
 RUN cp ./main /bin/s3bucket_exporter
 
-# Cleanup
-WORKDIR /
-RUN rm -Rf /build
-
+FROM debian:buster-slim
+COPY --from=builder /bin/s3bucket_exporter /bin/s3bucket_exporter
+WORKDIR /tmp
 ENTRYPOINT ["/bin/s3bucket_exporter"]


### PR DESCRIPTION
Image built from upstream weights 1.33GB, while the s3 bucket exporter
binary weights 23.1MB.

Tried to ship exporter in an image built FROM scratch, then from
an alpine base, though both would crash with some `no such file or
directory`. Meanwhile, a debian:buster-slim seems to work, reducing
image size to 92.5MB.

Also swaps WORKDIR. The temporary file written by the exporter, in the process of gathering metrics, should not be stored in the container root: moving it to something like /tmp, we then ensure that path can be written by some unprivileged user.